### PR TITLE
Leksička izmena

### DIFF
--- a/localization/serbian.cfg
+++ b/localization/serbian.cfg
@@ -1,5 +1,5 @@
 ako
-tada
+onda
 inace
 kraj
 ponovi


### PR DESCRIPTION
Menja `tada` sa `onda` jer je prva vremenska odrednica u određenog pridevskog vida, dok je pravilnije koristiti prostu uslovnu odrednicu "onda". Ako -> onda implicira napredak kroz ostvarenje uslova, ne kroz vreme.
